### PR TITLE
Update link for Argparse Cookbook

### DIFF
--- a/search.xml
+++ b/search.xml
@@ -90,7 +90,7 @@
       <url>/2018/01/13/python-argparse-module/</url>
       <content type="html"><![CDATA[<h2 id="简介"><a href="#简介" class="headerlink" title="简介"></a>简介</h2><p>Argparse 是提升命令行运行灵活度的神器，能在每次运行的时候传递一些特定参数给程序。</p>
 <a id="more"></a>
-<h2 id="Reference"><a href="#Reference" class="headerlink" title="Reference"></a>Reference</h2><p>[1] <a href="https://mkaz.tech/code/python-argparse-cookbook/" target="_blank" rel="external">Argparse Cookbook</a><br>[2] <a href="https://docs.python.org/3/howto/argparse.html" target="_blank" rel="external">Argparse Tutorial</a><br>[3] <a href="https://docs.python.org/3/library/argparse.html" target="_blank" rel="external">Argparse Library</a></p>
+<h2 id="Reference"><a href="#Reference" class="headerlink" title="Reference"></a>Reference</h2><p>[1] <a href="https://mkaz.blog/code/python-argparse-cookbook/" target="_blank" rel="external">Argparse Cookbook</a><br>[2] <a href="https://docs.python.org/3/howto/argparse.html" target="_blank" rel="external">Argparse Tutorial</a><br>[3] <a href="https://docs.python.org/3/library/argparse.html" target="_blank" rel="external">Argparse Library</a></p>
 ]]></content>
       
         <categories>


### PR DESCRIPTION
Update link to new domain for Argparse cookbook, redirects are currently in place but domain will expire.